### PR TITLE
Correction of a couple of typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,41 @@
 # PythonAnywhere Model Context Protocol Server
 
-A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) 
-server acts as a bridge between AI-powered tools and your 
-[PythonAnywhere](https://www.pythonanywhere.com/) account, enabling secure, 
-programmatic management of files, websites, webapps, and scheduled tasks. By 
-exposing a standardized interface, it allows language models and automation 
-clients to perform operations—such as editing files, deploying web apps, or 
+A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction)
+server acts as a bridge between AI-powered tools and your
+[PythonAnywhere](https://www.pythonanywhere.com/) account, enabling secure,
+programmatic management of files, websites, webapps, and scheduled tasks. By
+exposing a standardized interface, it allows language models and automation
+clients to perform operations—such as editing files, deploying web apps, or
 scheduling jobs -- on your behalf, all while maintaining fine-grained control
 and auditability.
 
 ## Features
-- **File management**: Read, upload, delete files and list directory trees. 
+- **File management**: Read, upload, delete files and list directory trees.
   _(also enables debugging with direct access to log files, which are just
   files on PythonAnywhere)_
 - **ASGI Web app management**: Create, delete, reload, and list.
-  _(as described in the [PythonAnywhere ASGI 
+  _(as described in the [PythonAnywhere ASGI
   documentation](https://help.pythonanywhere.com/pages/ASGICommandLine))_
 - **WSGI Web app management**: Reload only _(at the moment)_.
 - **Scheduled task management**: List, create, update, and delete.
-  _(Note that this enables LLMs to execute arbitrary commands if a task is 
-  scheduled to soon after creation and deleted after execution. For that we 
+  _(Note that this enables LLMs to execute arbitrary commands if a task is
+  scheduled too soon after creation and deleted after execution. For that we
   would suggest running it with [mcp-server-time](https://pypi.org/project/mcp-server-time/)
   as models easily get confused about time.)_
 
 ## Installation
-The MCP protocol is well-defined and supported by various clients, but 
-installation is different depending on the client you are using. We will 
+The MCP protocol is well-defined and supported by various clients, but
+installation is different depending on the client you are using. We will
 cover cases that we tried and tested.
 
 In all cases, you need to have `uv` installed and available in your `PATH`.
 
-Have your PythonAnywhere API token and username ready. You can find (or 
-generate) your API token in the [API section of your PythonAnywhere 
+Have your PythonAnywhere API token and username ready. You can find (or
+generate) your API token in the [API section of your PythonAnywhere
 account](https://www.pythonanywhere.com/account/#api_token).
 
 ### Desktop Extension - works with Claude Desktop
-Probably the most straightforward way to install the MCP server is to use 
+Probably the most straightforward way to install the MCP server is to use
 the [desktop extension](https://github.com/anthropics/dxt/) for Claude Desktop.
 
 1. Open Claude Desktop.
@@ -73,7 +73,7 @@ Add it to your `mcp.json`.
 ```
 
 ### Claude Desktop (manual setup) and Cursor:
-Add it to `claude_desktop_config.json` (for Claude Desktop) or (`mcp.json` 
+Add it to `claude_desktop_config.json` (for Claude Desktop) or (`mcp.json`
 for Cursor).
 
 ```json
@@ -94,20 +94,20 @@ for Cursor).
 
 ## Caveats
 
-Direct integration of an LLM with your PythonAnywhere account offers 
-significant capabilities, but also introduces risks. We strongly advise 
-maintaining human oversight, especially for sensitive actions such as 
+Direct integration of an LLM with your PythonAnywhere account offers
+significant capabilities, but also introduces risks. We strongly advise
+maintaining human oversight, especially for sensitive actions such as
 modifying or deleting files.
 
-If you are running multiple MCP servers simultaneously, be 
+If you are running multiple MCP servers simultaneously, be
 cautious -- particularly if any server can access external resources you do not
-control, such as GitHub issues. These can become attack vectors. For more 
+control, such as GitHub issues. These can become attack vectors. For more
 details, see [this story](https://simonwillison.net/2025/Jul/6/supabase-mcp-lethal-trifecta/).
 
 ## Implementation
 
-The server uses the [python mcp sdk](https://github.com/modelcontextprotocol/python-sdk) 
-in connection with the [pythonanywhere-core](https://github.com/pythonanywhere/pythonanywhere-core) 
-package ([docs](https://core.pythonanywhere.com/)), which wraps a subset of the [PythonAnywhere 
-API](https://help.pythonanywhere.com/pages/API/) and may be expanded in 
+The server uses the [python mcp sdk](https://github.com/modelcontextprotocol/python-sdk)
+in connection with the [pythonanywhere-core](https://github.com/pythonanywhere/pythonanywhere-core)
+package ([docs](https://core.pythonanywhere.com/)), which wraps a subset of the [PythonAnywhere
+API](https://help.pythonanywhere.com/pages/API/) and may be expanded in
 the future as needed.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ server acts as a bridge between AI-powered tools and your
 programmatic management of files, websites, webapps, and scheduled tasks. By 
 exposing a standardized interface, it allows language models and automation 
 clients to perform operations—such as editing files, deploying web apps, or 
-scheduling jobs—on your behalf, all while maintaining fine-grained control
+scheduling jobs -- on your behalf, all while maintaining fine-grained control
 and auditability.
 
 ## Features
@@ -18,13 +18,13 @@ and auditability.
   documentation](https://help.pythonanywhere.com/pages/ASGICommandLine))_
 - **WSGI Web app management**: Reload only _(at the moment)_.
 - **Scheduled task management**: List, create, update, and delete.
-  _(Npote that it enables LLMs to execute arbitrary commands if a task is 
-  scheduled to soon after creation and deleted after execution. For that we  
+  _(Note that this enables LLMs to execute arbitrary commands if a task is 
+  scheduled to soon after creation and deleted after execution. For that we 
   would suggest running it with [mcp-server-time](https://pypi.org/project/mcp-server-time/)
   as models easily get confused about time.)_
 
 ## Installation
-MCP protocol is well-defined and supported by various clients, but 
+The MCP protocol is well-defined and supported by various clients, but 
 installation is different depending on the client you are using. We will 
 cover cases that we tried and tested.
 
@@ -100,14 +100,14 @@ maintaining human oversight, especially for sensitive actions such as
 modifying or deleting files.
 
 If you are running multiple MCP servers simultaneously, be 
-cautious—particularly if any server can access external resources you do not
+cautious -- particularly if any server can access external resources you do not
 control, such as GitHub issues. These can become attack vectors. For more 
 details, see [this story](https://simonwillison.net/2025/Jul/6/supabase-mcp-lethal-trifecta/).
 
 ## Implementation
 
-Server uses [python mcp sdk](https://github.com/modelcontextprotocol/python-sdk) 
-in connection with [pythonanywhere-core](https://github.com/pythonanywhere/pythonanywhere-core) 
-package ([docs](https://core.pythonanywhere.com/)) that wraps subset of [PythonAnywhere 
-API](https://help.pythonanywhere.com/pages/API/) and would be expanded in 
+The server uses the [python mcp sdk](https://github.com/modelcontextprotocol/python-sdk) 
+in connection with the [pythonanywhere-core](https://github.com/pythonanywhere/pythonanywhere-core) 
+package ([docs](https://core.pythonanywhere.com/)), which wraps a subset of the [PythonAnywhere 
+API](https://help.pythonanywhere.com/pages/API/) and may be expanded in 
 the future as needed.


### PR DESCRIPTION
It also looks like vim trimmed off trailing whitespace, so the diff is a tad hard to read -- sorry! -- but that also fixed a formatting issue where there was a rogue newline near the start.